### PR TITLE
chore/dev_utils: make dot_parser a test feature only again

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -54,14 +54,20 @@
 )]
 
 #[macro_use]
+#[cfg(feature = "testing")]
 extern crate criterion;
-extern crate parsec_dev_utils;
+#[cfg(feature = "testing")]
+extern crate parsec;
 
+#[cfg(feature = "testing")]
 use criterion::Criterion;
-use parsec_dev_utils::{
+
+#[cfg(feature = "testing")]
+use parsec::dev_utils::{
     Environment, ObservationCount, PeerCount, RngChoice, Schedule, ScheduleOptions,
 };
 
+#[cfg(feature = "testing")]
 fn bench(c: &mut Criterion) {
     let _ = c.bench_function("minimal", |b| {
         b.iter_with_setup(
@@ -79,5 +85,13 @@ fn bench(c: &mut Criterion) {
     });
 }
 
+#[cfg(feature = "testing")]
 criterion_group!(benches, bench);
+
+#[cfg(feature = "testing")]
 criterion_main!(benches);
+
+#[cfg(not(feature = "testing"))]
+fn main() {
+    println!("For benchmark tests, run with '--features=testing'.");
+}

--- a/src/dev_utils/dot_parser.rs
+++ b/src/dev_utils/dot_parser.rs
@@ -366,7 +366,6 @@ fn extract_between<'a>(input: &'a str, left: &str, right: &str) -> &'a str {
     unwrap!(unwrap!(input.split(left).nth(1)).split(right).next())
 }
 
-#[cfg(test)]
 mod tests {
     use super::*;
     use std::path::Path;

--- a/src/dev_utils/mod.rs
+++ b/src/dev_utils/mod.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 /// This is used to read a dumped dot file and rebuild the event graph and associated info.
+#[cfg(test)]
 mod dot_parser;
 mod environment;
 mod network;
@@ -14,6 +15,7 @@ mod peer;
 pub mod proptest;
 mod schedule;
 
+#[cfg(test)]
 pub use self::dot_parser::{parse_dot_file, ParsedContents};
 pub use self::environment::{Environment, ObservationCount, PeerCount, RngChoice};
 pub use self::network::Network;

--- a/src/gossip/event.rs
+++ b/src/gossip/event.rs
@@ -12,6 +12,8 @@ use gossip::content::Content;
 use gossip::packed_event::PackedEvent;
 use hash::Hash;
 use id::{PublicId, SecretId};
+#[cfg(test)]
+use mock::{PeerId, Transaction};
 use network_event::NetworkEvent;
 use observation::Observation;
 use peer_list::PeerList;
@@ -330,10 +332,7 @@ impl<T: NetworkEvent, P: PublicId> Debug for Event<T, P> {
     }
 }
 
-#[cfg(feature = "testing")]
-use mock::{PeerId, Transaction};
-
-#[cfg(feature = "testing")]
+#[cfg(test)]
 impl Event<Transaction, PeerId> {
     // Creates a new event using the input parameters directly
     pub(crate) fn new_from_dot_input(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ extern crate lazy_static;
 extern crate log;
 #[macro_use]
 extern crate maidsafe_utilities;
-#[cfg(feature = "testing")]
+#[cfg(any(test, feature = "testing"))]
 #[macro_use]
 extern crate proptest as proptest_crate;
 #[macro_use]
@@ -82,9 +82,6 @@ extern crate tiny_keccak;
 extern crate unwrap;
 
 mod block;
-#[doc(hidden)]
-#[cfg(feature = "testing")]
-pub mod dev_utils;
 mod dump_graph;
 mod error;
 mod gossip;
@@ -98,6 +95,9 @@ mod peer_list;
 mod round_hash;
 mod vote;
 
+#[doc(hidden)]
+#[cfg(any(test, feature = "testing"))]
+pub mod dev_utils;
 #[doc(hidden)]
 /// **NOT FOR PRODUCTION USE**: Mock types which trivially implement the required Parsec traits.
 ///

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -34,7 +34,7 @@ impl PeerId {
     }
 
     // Only being used by the dot_parser.
-    #[cfg(feature = "testing")]
+    #[cfg(test)]
     pub fn from_initial(initial: char) -> Self {
         for name in NAMES.iter() {
             if name.starts_with(initial) {

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -7,12 +7,16 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use block::Block;
+#[cfg(test)]
+use dev_utils::ParsedContents;
 use dump_graph;
 use error::Error;
 use gossip::{Event, PackedEvent, Request, Response};
 use hash::Hash;
 use id::SecretId;
 use meta_vote::{MetaVote, Step};
+#[cfg(test)]
+use mock::{PeerId, Transaction};
 use network_event::NetworkEvent;
 use observation::Observation;
 use peer_list::PeerList;
@@ -994,12 +998,7 @@ impl<T: NetworkEvent, S: SecretId> Drop for Parsec<T, S> {
     }
 }
 
-#[cfg(all(test, feature = "testing"))]
-use dev_utils::ParsedContents;
-#[cfg(all(test, feature = "testing"))]
-use mock::{PeerId, Transaction};
-
-#[cfg(all(test, feature = "testing"))]
+#[cfg(test)]
 impl Parsec<Transaction, PeerId> {
     #[allow(unused)]
     pub(crate) fn from_parsed_contents(peer_id: PeerId, parsed_contents: ParsedContents) -> Self {
@@ -1011,7 +1010,7 @@ impl Parsec<Transaction, PeerId> {
     }
 }
 
-#[cfg(all(test, feature = "testing"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use dev_utils::parse_dot_file;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -58,7 +58,6 @@
 extern crate maidsafe_utilities;
 #[cfg(feature = "testing")]
 extern crate parsec;
-#[cfg(feature = "testing")]
 #[macro_use]
 #[cfg(feature = "testing")]
 extern crate proptest;


### PR DESCRIPTION
This also fixes the compiler errors for the benchmark target.